### PR TITLE
feat : 회원탈퇴기능 구현

### DIFF
--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/community/repository/BoardRepository.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/community/repository/BoardRepository.kt
@@ -2,7 +2,9 @@ package org.team.b4.cosmicadventures.domain.community.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.team.b4.cosmicadventures.domain.community.model.Board
+import org.team.b4.cosmicadventures.domain.user.model.User
 
 interface BoardRepository : JpaRepository<Board, Long> {
     fun findByIdAndUserId(boardId: Long, userId: Long?): Board?
+    fun findByUser(user: User): List<Board>
 }

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/community/repository/CommentRepository.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/community/repository/CommentRepository.kt
@@ -3,6 +3,9 @@ package org.team.b4.cosmicadventures.domain.community.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.team.b4.cosmicadventures.domain.community.model.Board
 import org.team.b4.cosmicadventures.domain.community.model.Comment
+import org.team.b4.cosmicadventures.domain.user.model.User
 
 interface CommentRepository : JpaRepository<Comment, Long> {
+
+    fun findByUser(user: User): List<Comment>
 }

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/oauth2/api/oauth2login/service/SocialMemberService.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/oauth2/api/oauth2login/service/SocialMemberService.kt
@@ -3,6 +3,7 @@ package org.team.b4.cosmicadventures.domain.oauth2.api.oauth2login.service
 import org.springframework.stereotype.Service
 import org.team.b4.cosmicadventures.domain.oauth2.client.oauth2.OAuth2LoginUserInfo
 import org.team.b4.cosmicadventures.domain.user.model.Role
+import org.team.b4.cosmicadventures.domain.user.model.Status
 import org.team.b4.cosmicadventures.domain.user.model.User
 import org.team.b4.cosmicadventures.domain.user.repository.UserRepository
 
@@ -24,7 +25,8 @@ class SocialMemberService(
                 password = "",
                 introduction = "",
                 tlno = "",
-                role = Role.USER
+                role = Role.USER,
+                status = Status.NORMAL,
             )
             userRepository.save(newUser)
         }

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/controller/UserController.kt
@@ -106,4 +106,11 @@ class UserController(
             .ok(blacklistedTokens)
     }
 
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping("/withdrawal/{userId}")
+    fun withdrawal(@PathVariable userId: Long): ResponseEntity<String> {
+        userService.withdrawal(userId)
+        return ResponseEntity.ok("회원 탈퇴가 성공적으로 처리되었습니다.")
+    }
 }

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/dto/request/SignUpRequest.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/dto/request/SignUpRequest.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Email
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.multipart.MultipartFile
 import org.team.b4.cosmicadventures.domain.user.model.Role
+import org.team.b4.cosmicadventures.domain.user.model.Status
 import org.team.b4.cosmicadventures.domain.user.model.User
 import org.team.b4.cosmicadventures.global.validation.ValidPassword
 import org.team.b4.cosmicadventures.global.validation.ValidTlno
@@ -43,7 +44,8 @@ data class SignUpRequest(
             email = email,
             password = password,
             introduction = introduction,
-            tlno = tlno
+            tlno = tlno,
+            status = Status.NORMAL
         )
 
         //여기서는 회원가입 요청이 들어올 때, 프로필 이미지가 없을 경우에 대비하여 기본 이미지 URL을 설정

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/model/Status.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/model/Status.kt
@@ -1,0 +1,5 @@
+package org.team.b4.cosmicadventures.domain.user.model
+
+enum class Status {
+    NORMAL, WITHDRAWAL
+}

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/model/User.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/model/User.kt
@@ -38,6 +38,10 @@ class User(
     @Column(name = "provider_id")
     val providerId: String? = null,
 
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var status: Status,
+
     @Enumerated(EnumType.STRING)
     @Column(name = "provider")
     val provider: OAuth2Provider? = null,

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/repository/UserRepository.kt
@@ -3,6 +3,7 @@ package org.team.b4.cosmicadventures.domain.user.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.team.b4.cosmicadventures.domain.oauth2.domain.entity.OAuth2Provider
+import org.team.b4.cosmicadventures.domain.user.model.Status
 import org.team.b4.cosmicadventures.domain.user.model.User
 
 interface UserRepository:JpaRepository<User, Long> {
@@ -10,4 +11,5 @@ interface UserRepository:JpaRepository<User, Long> {
     fun findByProviderAndProviderId(provider: OAuth2Provider, toString: String): User?
     fun existsByEmail(email: String): Boolean
     fun findByEmail(email:String):User?
+    fun findByStatus(status: Status): List<User>
 }

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/scheduler/UserCleanupScheduler.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/scheduler/UserCleanupScheduler.kt
@@ -1,0 +1,34 @@
+package org.team.b4.cosmicadventures.domain.user.scheduler
+
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.team.b4.cosmicadventures.domain.community.repository.BoardRepository
+import org.team.b4.cosmicadventures.domain.community.repository.CommentRepository
+import org.team.b4.cosmicadventures.domain.user.model.Status
+import org.team.b4.cosmicadventures.domain.user.repository.UserRepository
+import java.time.LocalDate
+
+
+@Component
+class UserCleanupScheduler(
+    private val userRepository: UserRepository,
+    private val commentRepository: CommentRepository,
+    private val boardRepository: BoardRepository,
+) {
+    // 매일 자정에 실행되어 90일이 지난 WAIT 상태인 사용자를 삭제 및 게시글과 댓글도 삭제
+    @Scheduled(cron = "0 0 0 * * ?")
+    fun cleanupWaitUsers() {
+        val thresholdDate = LocalDate.now().minusDays(90)
+        val WITHDRAWALUsers = userRepository.findByStatus(Status.WITHDRAWAL)
+        WITHDRAWALUsers.forEach { user ->
+            val createdAtDate = user.createdAt.toLocalDate()
+            if (createdAtDate.isBefore(thresholdDate)) {
+                val userPosts = boardRepository.findByUser(user)
+                userPosts.forEach { boardRepository.delete(it) }
+                val userComments = commentRepository.findByUser(user)
+                userComments.forEach { commentRepository.delete(it) }
+                userRepository.delete(user)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/SlangFilterService.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/SlangFilterService.kt
@@ -17,7 +17,7 @@ class SlangFilterService(
     private val logger = LoggerFactory.getLogger(SlangFilterService::class.java)
 
     fun isCleanText(userInput: String): Boolean {
-        val openaiApiKey = "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"
+        val openaiApiKey = "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"
         val apiUrl = "https://api.openai.com/v1/chat/completions"
         val requestBody = mapOf(
             "model" to "gpt-3.5-turbo",

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/UserService.kt
@@ -17,4 +17,5 @@ interface UserService {
         fun login(request: LoginRequest,response: HttpServletResponse): LoginResponse
         fun updatePassword(userId: Long,request: UpdateUserPasswordRequest):String
         fun logout(response: HttpServletResponse, request: HttpServletRequest)
+        fun withdrawal(userId: Long)
 }

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/UserServiceImpl.kt
@@ -95,17 +95,20 @@ class UserServiceImpl(
         jwtPlugin.invalidateToken(accessToken)
     }
 
-    @Transactional
     override fun withdrawal(userId: Long) {
-
-        val authenticatedId: Long = (SecurityContextHolder.getContext().authentication.principal as UserPrincipal).id
-        if (userId != authenticatedId) {
-            throw IllegalArgumentException("탈퇴 권한이 없습니다.")
+        val principal = SecurityContextHolder.getContext().authentication.principal
+        if (principal is UserPrincipal) {
+            val authenticatedId: Long = principal.id
+            if (userId != authenticatedId) {
+                throw IllegalArgumentException("탈퇴 권한이 없습니다.")
+            }
+            val user = userRepository.findById(userId)
+                .orElseThrow { throw IllegalArgumentException("해당 회원을 찾을 수 없습니다.") }
+            user.status = Status.WITHDRAWAL
+            userRepository.save(user)
+        } else {
+            throw IllegalStateException("로그인을 해주세요.")
         }
-        val user = userRepository.findById(userId)
-            .orElseThrow { throw IllegalArgumentException("해당 회원을 찾을 수 없습니다.") }
-        user.status= Status.WITHDRAWAL
-        userRepository.save(user)
     }
 
     override fun updatePassword(

--- a/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/org/team/b4/cosmicadventures/domain/user/service/UserServiceImpl.kt
@@ -95,6 +95,19 @@ class UserServiceImpl(
         jwtPlugin.invalidateToken(accessToken)
     }
 
+    @Transactional
+    override fun withdrawal(userId: Long) {
+
+        val authenticatedId: Long = (SecurityContextHolder.getContext().authentication.principal as UserPrincipal).id
+        if (userId != authenticatedId) {
+            throw IllegalArgumentException("탈퇴 권한이 없습니다.")
+        }
+        val user = userRepository.findById(userId)
+            .orElseThrow { throw IllegalArgumentException("해당 회원을 찾을 수 없습니다.") }
+        user.status= Status.WITHDRAWAL
+        userRepository.save(user)
+    }
+
     override fun updatePassword(
         userId: Long,
         request: UpdateUserPasswordRequest
@@ -145,11 +158,9 @@ class UserServiceImpl(
             if (uploadedImageStrings != null) {
                 profilePicUrl = uploadedImageStrings
             }
-
         })
         val verificationCode = UUID.randomUUID().toString().substring(0, 6)
         user.verificationCode = verificationCode
-
         userRepository.save(user)
         emailService.sendVerificationEmail(user.email, verificationCode)
         return UserResponse.from(user)
@@ -177,6 +188,7 @@ class UserServiceImpl(
         }
         return UserResponse.from(user)
     }
+
 
 
 


### PR DESCRIPTION
1. 회원상태 추가 / 기본은 NORMAL 탈퇴을 했을시 WITHDRAWAL 상태변경
2. WITHDRAWAL 상태변경된 유저는 90일이 지나면 게시글과 댓글 유저의정보까지 삭제

## 연관된 이슈

> #23 

## 작업 내용

- [ ]
- [ ]
- [ ]

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
